### PR TITLE
Utilized NetIds to get drops for structures and barricades rather than find by root.

### DIFF
--- a/SellDoor/Helpers/BarricadeHelper.cs
+++ b/SellDoor/Helpers/BarricadeHelper.cs
@@ -1,4 +1,5 @@
 ﻿using SDG.Unturned;
+using Steamworks;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,12 +21,19 @@ namespace RestoreMonarchy.SellDoor.Helpers
 
             foreach (Transform result in results)
             {
-                BarricadeDrop barricadeDrop = BarricadeManager.FindBarricadeByRootTransform(result);
-                BarricadeData barricadeData = barricadeDrop.GetServersideData();
 
-                if (barricadeData.point == point && barricadeDrop.asset.GUID == assetGuid)
+                NetId netId = NetIdRegistry.GetTransformNetId(result);
+                if (netId == NetId.INVALID)
+                    return null;
+                netId.id--;
+                BarricadeDrop drop = NetIdRegistry.Get<BarricadeDrop>(netId);
+
+
+                BarricadeData barricadeData = drop.GetServersideData();
+
+                if (barricadeData.point == point && drop.asset.GUID == assetGuid)
                 {
-                    return barricadeDrop;
+                    return drop;
                 }
             }
 
@@ -41,7 +49,14 @@ namespace RestoreMonarchy.SellDoor.Helpers
 
             Transform transform = BarricadeManager.dropNonPlantedBarricade(barricade, point, rotation, owner, group);
 
-            return BarricadeManager.FindBarricadeByRootTransform(transform);
+
+            NetId netId = NetIdRegistry.GetTransformNetId(transform);
+            if (netId == NetId.INVALID)
+                return null;
+            netId.id--;
+            BarricadeDrop drop = NetIdRegistry.Get<BarricadeDrop>(netId);
+
+            return drop;
         }  
     }
 }

--- a/SellDoor/Helpers/BarricadeHelper.cs
+++ b/SellDoor/Helpers/BarricadeHelper.cs
@@ -21,16 +21,15 @@ namespace RestoreMonarchy.SellDoor.Helpers
 
             foreach (Transform result in results)
             {
-
                 NetId netId = NetIdRegistry.GetTransformNetId(result);
                 if (netId == NetId.INVALID)
-                    return null;
+                    continue;
                 netId.id--;
                 BarricadeDrop drop = NetIdRegistry.Get<BarricadeDrop>(netId);
-
+                if (drop == null)
+                    continue;
 
                 BarricadeData barricadeData = drop.GetServersideData();
-
                 if (barricadeData.point == point && drop.asset.GUID == assetGuid)
                 {
                     return drop;
@@ -49,14 +48,11 @@ namespace RestoreMonarchy.SellDoor.Helpers
 
             Transform transform = BarricadeManager.dropNonPlantedBarricade(barricade, point, rotation, owner, group);
 
-
             NetId netId = NetIdRegistry.GetTransformNetId(transform);
             if (netId == NetId.INVALID)
                 return null;
             netId.id--;
-            BarricadeDrop drop = NetIdRegistry.Get<BarricadeDrop>(netId);
-
-            return drop;
+            return NetIdRegistry.Get<BarricadeDrop>(netId);
         }  
     }
 }

--- a/SellDoor/Helpers/RaycastHelper.cs
+++ b/SellDoor/Helpers/RaycastHelper.cs
@@ -1,4 +1,5 @@
 ﻿using SDG.Unturned;
+using Steamworks;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -22,7 +23,12 @@ namespace RestoreMonarchy.SellDoor.Helpers
                     transform = door.transform;
                 }
 
-                drop = BarricadeManager.FindBarricadeByRootTransform(transform);
+                NetId netId = NetIdRegistry.GetTransformNetId(transform);
+                if (netId == NetId.INVALID)
+                    return null;
+                netId.id--;
+                drop = NetIdRegistry.Get<BarricadeDrop>(netId);
+
                 if (drop != null)
                 {
                     barricadeData = drop.GetServersideData();
@@ -40,7 +46,11 @@ namespace RestoreMonarchy.SellDoor.Helpers
             Ray ray = new Ray(player.look.aim.position, player.look.aim.forward);
             if (Physics.Raycast(ray, out hit, 3, RayMasks.STRUCTURE_INTERACT))
             {
-                StructureDrop drop = StructureManager.FindStructureByRootTransform(hit.transform);
+                NetId netId = NetIdRegistry.GetTransformNetId(hit.transform);
+                if (netId == NetId.INVALID)
+                    return null;
+                netId.id--;
+                StructureDrop drop = NetIdRegistry.Get<StructureDrop>(netId);
                 if (drop != null)
                 {
                     structureData = drop.GetServersideData();
@@ -62,7 +72,13 @@ namespace RestoreMonarchy.SellDoor.Helpers
             {
                 if (transform.position == position)
                 {
-                    return BarricadeManager.FindBarricadeByRootTransform(transform)?.model ?? null;
+
+                    NetId netId = NetIdRegistry.GetTransformNetId(transform);
+                    if (netId == NetId.INVALID)
+                        return null;
+                    netId.id--;
+                    BarricadeDrop drop = NetIdRegistry.Get<BarricadeDrop>(netId);
+                    return drop?.model ?? null;
                 }
             }
             return null;
@@ -79,7 +95,12 @@ namespace RestoreMonarchy.SellDoor.Helpers
             {
                 if (transform.position == position)
                 {
-                    return StructureManager.FindStructureByRootTransform(transform)?.model ?? null;
+                    NetId netId = NetIdRegistry.GetTransformNetId(transform);
+                    if (netId == NetId.INVALID)
+                        return null;
+                    netId.id--;
+                    StructureDrop drop = NetIdRegistry.Get<StructureDrop>(netId);
+                    return drop?.model ?? null;
                 }
             }
 

--- a/SellDoor/Helpers/RaycastHelper.cs
+++ b/SellDoor/Helpers/RaycastHelper.cs
@@ -72,13 +72,13 @@ namespace RestoreMonarchy.SellDoor.Helpers
             {
                 if (transform.position == position)
                 {
-
                     NetId netId = NetIdRegistry.GetTransformNetId(transform);
                     if (netId == NetId.INVALID)
-                        return null;
+                        continue;
                     netId.id--;
                     BarricadeDrop drop = NetIdRegistry.Get<BarricadeDrop>(netId);
-                    return drop?.model ?? null;
+                    if (drop != null)
+                        return drop.model;
                 }
             }
             return null;
@@ -97,10 +97,11 @@ namespace RestoreMonarchy.SellDoor.Helpers
                 {
                     NetId netId = NetIdRegistry.GetTransformNetId(transform);
                     if (netId == NetId.INVALID)
-                        return null;
+                        continue;
                     netId.id--;
                     StructureDrop drop = NetIdRegistry.Get<StructureDrop>(netId);
-                    return drop?.model ?? null;
+                    if (drop != null)
+                        return drop.model;
                 }
             }
 

--- a/SellDoor/Helpers/StructureHelper.cs
+++ b/SellDoor/Helpers/StructureHelper.cs
@@ -7,8 +7,10 @@ namespace RestoreMonarchy.SellDoor.Helpers
 {
     public class StructureHelper
     {
+        /*
         public static StructureDrop FindStructureDropByPosition(Guid assetGuid, Vector3 point)
         {
+            
             List<RegionCoordinate> regions = new();
             Regions.getRegionsInRadius(point, 0.1f, regions);
 
@@ -17,17 +19,25 @@ namespace RestoreMonarchy.SellDoor.Helpers
 
             foreach (Transform result in results)
             {
-                StructureDrop structureDrop = StructureManager.FindStructureByRootTransform(result);
-                StructureData structureData = structureDrop.GetServersideData();
+                NetId netId = NetIdRegistry.GetTransformNetId(result);
+                if (netId == NetId.INVALID)
+                    return null;
+                netId.id--;
+                StructureDrop drop = NetIdRegistry.Get<StructureDrop>(netId);
+                StructureData structureData = drop.GetServersideData();
 
-                if (structureData.point == point && structureDrop.asset.GUID == assetGuid)
+                if (structureData.point == point && drop.asset.GUID == assetGuid)
                 {
-                    return structureDrop;
+                    return drop;
                 }
             }
+            
+
+            
 
             return null;
         }
+        */
 
         public static StructureDrop ForceDropStructure(ItemStructureAsset asset, Vector3 point, Vector3 angle, ulong owner, ulong group)
         {
@@ -36,7 +46,11 @@ namespace RestoreMonarchy.SellDoor.Helpers
 
             StructureManager.dropReplicatedStructure(structure, point, rotation, owner, group);
 
-            return FindStructureDropByPosition(asset.GUID, point);
+            NetId dropNetId = new NetId(NetIdRegistry.counter - 2);
+
+            StructureDrop drop = NetIdRegistry.Get<StructureDrop>(dropNetId);
+
+            return drop;
         }
     }
 }

--- a/SellDoor/Helpers/StructureHelper.cs
+++ b/SellDoor/Helpers/StructureHelper.cs
@@ -1,44 +1,10 @@
-﻿using SDG.Unturned;
-using System;
-using System.Collections.Generic;
+using SDG.Unturned;
 using UnityEngine;
 
 namespace RestoreMonarchy.SellDoor.Helpers
 {
     public class StructureHelper
     {
-        /*
-        public static StructureDrop FindStructureDropByPosition(Guid assetGuid, Vector3 point)
-        {
-            
-            List<RegionCoordinate> regions = new();
-            Regions.getRegionsInRadius(point, 0.1f, regions);
-
-            List<Transform> results = new();
-            StructureManager.getStructuresInRadius(point, 0.1f, regions, results);
-
-            foreach (Transform result in results)
-            {
-                NetId netId = NetIdRegistry.GetTransformNetId(result);
-                if (netId == NetId.INVALID)
-                    return null;
-                netId.id--;
-                StructureDrop drop = NetIdRegistry.Get<StructureDrop>(netId);
-                StructureData structureData = drop.GetServersideData();
-
-                if (structureData.point == point && drop.asset.GUID == assetGuid)
-                {
-                    return drop;
-                }
-            }
-            
-
-            
-
-            return null;
-        }
-        */
-
         public static StructureDrop ForceDropStructure(ItemStructureAsset asset, Vector3 point, Vector3 angle, ulong owner, ulong group)
         {
             Structure structure = new(asset, asset.health);
@@ -46,11 +12,9 @@ namespace RestoreMonarchy.SellDoor.Helpers
 
             StructureManager.dropReplicatedStructure(structure, point, rotation, owner, group);
 
-            NetId dropNetId = new NetId(NetIdRegistry.counter - 2);
-
-            StructureDrop drop = NetIdRegistry.Get<StructureDrop>(dropNetId);
-
-            return drop;
+            // dropReplicatedStructure goes through ClaimBlock(2u): drop is at counter-1, transform at counter.
+            NetId dropNetId = new NetId(NetIdRegistry.counter - 1);
+            return NetIdRegistry.Get<StructureDrop>(dropNetId);
         }
     }
 }

--- a/SellDoor/Models/Door.cs
+++ b/SellDoor/Models/Door.cs
@@ -39,7 +39,11 @@ namespace RestoreMonarchy.SellDoor.Models
         {
             steamID = CSteamID.Nil;
             groupID = CSteamID.Nil;
-            BarricadeDrop drop = BarricadeManager.FindBarricadeByRootTransform(Transform);
+            NetId netId = NetIdRegistry.GetTransformNetId(Transform);
+            if (netId == NetId.INVALID)
+                return false;
+            netId.id--;
+            BarricadeDrop drop = NetIdRegistry.Get<BarricadeDrop>(netId);
             if (drop == null)
             {
                 return false;

--- a/SellDoor/Models/DoorItem.cs
+++ b/SellDoor/Models/DoorItem.cs
@@ -1,5 +1,6 @@
 ﻿using SDG.Unturned;
 using Steamworks;
+using UnityEngine;
 
 namespace RestoreMonarchy.SellDoor.Models
 {
@@ -29,7 +30,11 @@ namespace RestoreMonarchy.SellDoor.Models
                 return;
             }                
 
-            BarricadeDrop drop = BarricadeManager.FindBarricadeByRootTransform(Transform);
+            NetId netId = NetIdRegistry.GetTransformNetId(Transform);
+            if (netId == NetId.INVALID)
+                return;
+            netId.id--;
+            BarricadeDrop drop = NetIdRegistry.Get<BarricadeDrop>(netId);
             if (drop == null)
             {
                 return;

--- a/SellDoor/Models/TransformBase.cs
+++ b/SellDoor/Models/TransformBase.cs
@@ -25,31 +25,24 @@ namespace RestoreMonarchy.SellDoor.Models
 
                 if (AssetId == null)
                 {
-                    BarricadeDrop drop = null;
                     NetId netId = NetIdRegistry.GetTransformNetId(Transform);
                     if (netId != NetId.INVALID)
                     {
                         netId.id--;
-                        drop = NetIdRegistry.Get<BarricadeDrop>(netId);
-                    }
-                    if (drop != null)
-                    {
-                        AssetId = drop.asset.GUID;
-                        AssetName = drop.asset.itemName;
-                    }
-                    else
-                    {
-                        StructureDrop structureDrop = null;
-                        NetId structureNetId = NetIdRegistry.GetTransformNetId(Transform);
-                        if (structureNetId != NetId.INVALID)
+                        BarricadeDrop drop = NetIdRegistry.Get<BarricadeDrop>(netId);
+                        if (drop != null)
                         {
-                            structureNetId.id--;
-                            structureDrop = NetIdRegistry.Get<StructureDrop>(structureNetId);
+                            AssetId = drop.asset.GUID;
+                            AssetName = drop.asset.itemName;
                         }
-                        if (structureDrop != null)
+                        else
                         {
-                            AssetId = structureDrop.asset.GUID;
-                            AssetName = structureDrop.asset.itemName;
+                            StructureDrop structureDrop = NetIdRegistry.Get<StructureDrop>(netId);
+                            if (structureDrop != null)
+                            {
+                                AssetId = structureDrop.asset.GUID;
+                                AssetName = structureDrop.asset.itemName;
+                            }
                         }
                     }
                 }

--- a/SellDoor/Models/TransformBase.cs
+++ b/SellDoor/Models/TransformBase.cs
@@ -25,7 +25,13 @@ namespace RestoreMonarchy.SellDoor.Models
 
                 if (AssetId == null)
                 {
-                    BarricadeDrop drop = BarricadeManager.FindBarricadeByRootTransform(Transform);
+                    BarricadeDrop drop = null;
+                    NetId netId = NetIdRegistry.GetTransformNetId(Transform);
+                    if (netId != NetId.INVALID)
+                    {
+                        netId.id--;
+                        drop = NetIdRegistry.Get<BarricadeDrop>(netId);
+                    }
                     if (drop != null)
                     {
                         AssetId = drop.asset.GUID;
@@ -33,8 +39,14 @@ namespace RestoreMonarchy.SellDoor.Models
                     }
                     else
                     {
-                        StructureDrop structureDrop = StructureManager.FindStructureByRootTransform(Transform);
-                        if (drop != null)
+                        StructureDrop structureDrop = null;
+                        NetId structureNetId = NetIdRegistry.GetTransformNetId(Transform);
+                        if (structureNetId != NetId.INVALID)
+                        {
+                            structureNetId.id--;
+                            structureDrop = NetIdRegistry.Get<StructureDrop>(structureNetId);
+                        }
+                        if (structureDrop != null)
                         {
                             AssetId = structureDrop.asset.GUID;
                             AssetName = structureDrop.asset.itemName;

--- a/SellDoor/SellDoor.csproj
+++ b/SellDoor/SellDoor.csproj
@@ -8,8 +8,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="Krafs.Publicizer" Version="2.3.0">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
 	  <PackageReference Include="Lib.Harmony" Version="2.3.3" />
 	  <PackageReference Include="RestoreMonarchy.RocketRedist" Version="3.24.6" ExcludeAssets="runtime" />
+	  <Publicize Include="Assembly-CSharp:SDG.Unturned.NetIdRegistry.counter"/>
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Earlier I discovered that `BarricadeDrop.FindByRootFast` utilizes `GetComponent` in order to obtain the BarricadeDrop. Nelson likes to return transforms for new plants and finding barricades in a radius, so this is called fairly often.

By utilizing the NetIdRegistry and therefore its built-in dictionaries, you save 31.64 - 48% in tick speed in comparison to the FindByRootFast way. I've tested this alongside RBMKBlaze in relation to a plugin on LC and it gives a noticeable improvement.

```csharp
            NetId netId = NetIdRegistry.GetTransformNetId(__instance.transform);
            if (netId == NetId.INVALID)
                return;
             netId.id--;

            BarricadeDrop drop = (BarricadeDrop)NetIdRegistry.Get(netId);
```

This is the new standard and improved way to get `BarricadeDrop` from a Transform. Tons of plugins use the old FindBarricadeByRootTransform way and it can be incredibly problematic.